### PR TITLE
ci/docs: add release workflow (publish to pypi) and a RELEASE.md file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+# Test build of release artifacts (PyPI package) and publish them on pushed git
+# tags.
+#
+name: Release
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/release.yaml"
+  push:
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/release.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
+  workflow_dispatch:
+
+jobs:
+  build-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: install build requirements
+        run: |
+          pip install --upgrade pip
+          pip install build twine
+          pip list
+
+      - name: build release
+        run: |
+          python -m build --sdist --wheel .
+          ls -l dist
+
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          twine upload --skip-existing dist/*

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,70 @@
+# How to make a release
+
+`gh-scoped-creds` is a package [available on
+PyPI](https://pypi.org/project/gh-scoped-creds/) and on conda-forge.
+
+These are instructions on how to make a release on PyPI. The PyPI release is
+done automatically by CI when a git tag is pushed. Following a PyPI release is
+made, a pull request will be opened to the conda-forge feedstock.
+
+For you to follow along according to these instructions, you need:
+
+- To have push rights to the [gh-scoped-creds GitHub
+  repository](https://github.com/jupyterhub/gh-scoped-creds).
+
+## Steps to make a release
+
+1. Make sure `CHANGELOG.md` is up-to-date ahead of time with a dedicated
+   changelog PR. [github-activity][] can help with this.
+
+1. Checkout main and make sure it is up to date.
+
+   ```shell
+   ORIGIN=${ORIGIN:-origin} # set to the canonical remote, e.g. 'upstream' if 'origin' is not the official repo
+   git checkout main
+   git fetch $ORIGIN main
+   git reset --hard $ORIGIN/main
+   # WARNING! This next command deletes any untracked files in the repo
+   git clean -xfd
+   ```
+
+1. Set the `version` field in setup.py appropriately and make a commit.
+
+   ```shell
+   git add setup.py
+   VERSION=...  # e.g. 1.2.3
+   git commit -m "release $VERSION"
+   git tag -a $VERSION -m $VERSION HEAD
+   ```
+
+1. Reset the version field in setup.py appropriately with an incremented patch
+   version and a dev element, then make a commit.
+
+   ```shell
+   git add setup.py
+   git commit -m "back to dev"
+   ```
+
+1. Verify your git history looks good.
+
+   ```shell
+   git log
+   ```
+
+1. Push the commits and git tags.
+
+   ```
+   git push --atomic --follow-tags $ORIGIN main
+   ```
+
+1. Verify that [the GitHub workflow](https://github.com/jupyterhub/gh-scoped-creds/actions?query=workflow%3ARelease)
+   triggers and succeeds, and that that [the PyPI
+   project](https://pypi.org/project/gh-scoped-creds) received a new release.
+
+1. Following the release to PyPI, an automated PR should arrive to
+   [conda-forge/gh-scoped-creds-feedstock][], check for the tests to succeed on
+   this PR and then merge it to successfully update the package for `conda` on
+   the conda-forge channel.
+
+[github-activity]: https://github.com/executablebooks/github-activity
+[conda-forge/gh-scoped-creds-feedstock]: https://github.com/conda-forge/gh-scoped-creds-feedstock


### PR DESCRIPTION
### PR Summary

- The github secret `PYPI_PASSWORD` is added already, based on a deployment token for our PyPI bot account now with maintainer permissions for the associated PyPI project.
- Added a copy/pasted/tweaked RELEASE.md based on this workflow of relying on the github CI system to do upload to PyPI.

### Related

It would be nice to retroactively add tags to the commits associated with the previous releases and push those before merging this to avoid triggering workflows that would try publish to PyPI. If that is done later, they won't override any PyPI release though because the upload command looks like this: `twine upload --skip-existing dist/*`

- #35