### PR TITLE
Update GitHub App configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,25 +51,28 @@ pip install gh-scoped-creds
    Developer Settings -> GitHub Apps -> New GitHub app from the organization's
    GitHub page).
 
-2. Give it a descriptive name and description, as your users will see this
+1. Give it a descriptive name and description, as your users will see this
    when they authenticate. Provide a link to a descriptive page explaining your
    service (if you are using a JupyterHub, this could be just your JupyterHub URL).
 
-3. Select 'Enable Device Flow', as we rely on the [device flow](https://docs.github.com/en/enterprise-server@3.3/developers/apps/building-oauth-apps/authorizing-oauth-apps#device-flow)
+1. Keep the 'Expire user authorization tokens' box checked. The authorisation will
+   expire after 8 hours by default.
+
+1. Select 'Enable Device Flow', as we rely on the [device flow](https://docs.github.com/en/enterprise-server@3.3/developers/apps/building-oauth-apps/authorizing-oauth-apps#device-flow)
    authentication method.
 
-4. Disable webhooks (uncheck the 'Active' checkbox under 'Webhooks'). All other
+1. Disable webhooks (uncheck the 'Active' checkbox under 'Webhooks'). All other
    textboxes can be left empty.
 
-5. Under 'Repository permissions', select 'Read & write' for 'Contents'. This
+1. Under 'Repository permissions', select 'Read & write' for 'Contents'. This
    will provide users authenticating via the app just enough permissions to push
    and pull from repositories.
 
-6. Under 'Where can this GitHub App be installed?', select 'Any account'. This will
+1. Under 'Where can this GitHub App be installed?', select 'Any account'. This will
    enable users to push to their own user repositories or other organization repositaries,
    rather than just the repos of the user or organization owning this GitHub app.
 
-7. Save the `Client ID` provided in the information page of the app. You'll need this
+1. Save the `Client ID` provided in the information page of the app. You'll need this
    in the client. Save the `Public link` as well, as users will need to use this to grant
    access to particular repositories.
 


### PR DESCRIPTION
There is a new app configuration option to

- [ ] **Expire user authorization tokens**

This update the README to keep this option checked, otherwise `gh-scoped-creds` will throw an error since `access_resp["expires_in"]` is not set.

See [GitHub docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/token-expiration-and-revocation#user-token-expired-due-to-github-app-configuration).